### PR TITLE
Fix display when the user only has the last name set

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -87,6 +87,8 @@ try {
 		$pm = true;
 		if(isset($info['User']['first_name'])) {
 			$name = $info['User']['first_name'];
+		} else if(isset($info['User']['last_name'])) {
+			$name = $info['User']['last_name'];
 		}
 	}
 	$channel = isset($info['channel_id']);

--- a/chats.php
+++ b/chats.php
@@ -329,6 +329,8 @@ try {
 							$n = $p['title'];
 						} else if(isset($p['first_name'])) {
 							$n = trim($p['first_name']).(isset($p['last_name']) ? ' '.trim($p['last_name']) : '');
+						} else if(isset($p['last_name'])) {
+							$n = trim($p['last_name']);
 						} else {
 							$n = 'Deleted Account';
 						}

--- a/chatselect.php
+++ b/chatselect.php
@@ -300,6 +300,8 @@ try {
 						$name = $p['title'];
 					} else if(isset($p['first_name'])) {
 						$name = trim($p['first_name']).(isset($p['last_name']) ? ' '.trim($p['last_name']) : '');
+					} else if(isset($p['last_name'])) {
+						$name = trim($p['last_name']);
 					} else {
 						$name = 'Deleted Account';
 					}

--- a/mp.php
+++ b/mp.php
@@ -73,11 +73,14 @@ class MP {
 
 	static function getNameFromInfo($p, $full = false) {
 		if(isset($p['User'])) {
-			if(!isset($p['User']['first_name'])) {
+			if(!isset($p['User']['first_name']) && !isset($p['User']['last_name'])) {
 				return 'Deleted Account';
 			}
 			try {
-				return trim($p['User']['first_name']).($full && isset($p['User']['last_name']) ? ' '.trim($p['User']['last_name']) : '');
+				$tr_first = isset($p['User']['first_name']) ? trim($p['User']['first_name']) : '';
+				$tr_last = $full && isset($p['User']['last_name']) ? ' '.trim($p['User']['last_name']) : '';
+
+				return $tr_first.$tr_last;
 			} catch (Exception $e) {
 				return '';
 			}


### PR DESCRIPTION
Hi Shinovon, 
Thanks for the awesome mpgram-web! 

I have some users in my contact list who only have the last name set. Because of that, their names were displayed as "Deleted Account" in `chats.php` and `chatselect.php`. Also, a crash occurred in `chat.php:193` since the name was null.

In this PR I patched this up so that I can chat with these contacts.

Suggestion:
1. Previously the user / chat names were all sourced from `getNameFromInfo` in `mp.php`, now this seems to be spread across 4 places
2. I suggest centralising this logic in one helper so that there is no duplication

P.S. Also thanks for implementing the message forwarding function recently, it really helps!