### PR TITLE
Add a docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,37 @@
 # MPGram Web
-Lightweight telegram web client based on MadelineProto
 
-Test instance: <a href="https://mp.nnchan.ru/">https://mp.nnchan.ru</a>, but it is highly recommended to make your own instance.
+Lightweight Telegram web client based on MadelineProto.
 
-## Setup notes
-- You need to create `config.php` and `api_values.php` config files (see examples)
-- You need to generate api id by creating a telegram app in <a href="https://my.telegram.org/apps">https://my.telegram.org/apps</a> and put `api_id` & `api_hash` into `api_values.php`
-- You should deny access to sessions folder (`s/` by default, see in `config.php`) and MadelineProto.log
-- You must have php-gd extension installed to get images working (`apt-get install php8.1-gd`)<br>
-and php-mbstring for MadelineProto (`apt-get install php8.1-mbstring`)
-- You need to set browscap in php.ini to get better device labels
-- MadelineProto install command: `composer update` (composer v2+ needs to be installed)
-- More instructions for installing MadelineProto <a href="https://docs.madelineproto.xyz/docs/INSTALLATION.html">here</a>
+Test instance is available at <a href="https://mp.nnchan.ru/">https://mp.nnchan.ru</a> (not guaranteed to run a stable version).
+
+_It is highly recommended to run your own instance (read on)._
+
+## Setup
+
+- Generate your own API id by creating a Telegram app at <a href="https://my.telegram.org/apps">https://my.telegram.org/apps</a> 
+- Create `api_value.php` from the `api_values.php.example` using the `api_id` and `api_hash` you generated
+- Create `config.php` from the `config.php.example`
+
+## Deployment
+
+### Docker
+
+You can deploy your own instance quickly with Docker Compose - [see how](https://github.com/shinovon/mpgram-web/blob/main/docker/README.md).
+
+### Manual deployment notes
+
+- You should deny access to sessions folder (`s/` by default, see in `config.php`) and `MadelineProto.log`
+- You must have `php-gd` extension installed to get images working (`apt-get install php8.1-gd`)<br>
+and `php-mbstring` for MadelineProto (`apt-get install php8.1-mbstring`)
+- You need to set [browscap](https://browscap.org/) in `php.ini` to get better logged in device names
+- Install Composer v2+
+- Install MadelineProto and its dependencies with `composer update`
+- For more details on installing MadelineProto <a href="https://docs.madelineproto.xyz/docs/INSTALLATION.html">see here</a>
 
 ## Tested browsers
+
 Fully supported:
+
 - Internet Explorer 6.0 and above
 - Opera 9.0 and above
 - Nokia Browser for Symbian (Symbian 9.2 and above)
@@ -23,7 +40,8 @@ Fully supported:
 - WebPositive
 - All modern browsers (Chrome, Safari, etc)
 
-Partially supported (Auto update doesn't work and/or no auto scroll)
+Partially supported (Auto update doesn't work and/or no auto scroll):
+
 - Internet Explorer 3.0-5.0
 - Opera Mini (All versions)
 - S40 5th Edition or older
@@ -32,3 +50,4 @@ Partially supported (Auto update doesn't work and/or no auto scroll)
 Not supported
 - Internet Explorer 2 and older
 - ?
+

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,16 @@
+# UID of the owner of the source dir on the host (`../mpgram-web`).
+# Run `id` to find it out.
+# Setting it ensures the mpgram container has write access it needs
+UID=1000
+
+# Bind nginx to a certain IP or open up (0.0.0.0)
+INTERFACE=0.0.0.0
+
+# http or https.
+# https needs an SSL certificate (see README.md)
+PROTO=http
+
+# web server ports
+PORT_HTTP=80
+PORT_HTTPS=443
+

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,4 @@
+.idea
+logs
+.env
+nginx/ssl

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,44 @@
+# Your own mpgram-web in 5 minutes
+
+## Requirements
+
+1. Docker Engine (see [instructions](https://docs.docker.com/engine/install/ubuntu/))
+2. [docker-compose](https://github.com/docker/compose).
+
+## Configuration
+
+Edit `../api_values.php` and `../config.php` as per mpgram-web's [README](https://github.com/shinovon/mpgram-web), then:
+
+```
+cp .env.example .env
+```
+
+See if you need to edit the ports, IP etc.
+
+### HTTP (default)
+
+You are all set!
+
+```
+docker-compose up --build -d
+```
+
+Your mpgram will await you on [http://127.0.0.1](http://127.0.0.1).
+
+### HTTPS (recommended)
+
+* Place your SSL chain certificate (named `fullchain.pem`) and private key (named `privkey.pem`) into `nginx/ssl`
+* Set `PROTO=https` in `.env`
+
+If you want to create a self-signed certificate instead of obtaining one from a CA, run:
+
+```
+openssl req -x509 -nodes -days 365 -subj "/C=CA/ST=QC/O=Company, Inc./CN=mydomain.com" -addext "subjectAltName=DNS:mydomain.com" -newkey rsa:2048 -keyout nginx/ssl/privkey.pem -out nginx/ssl/fullchain.pem
+```
+
+Add a `-sha1` option if you are targeting a retro platform like Symbian S60. **Warning**: [SHA1 is insecure!](https://en.wikipedia.org/wiki/SHA-1#Attacks).
+
+Run with `docker-compose` as per above.
+
+Happy mpgram'ming!
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '2'
+
+services:
+    nginx:
+        build:
+            context: nginx
+            args:
+                UID: ${UID}
+                PROTO: ${PROTO}
+        depends_on:
+            - app
+        volumes_from:
+            - app
+        ports:
+            - '${INTERFACE}:${PORT_HTTP}:80'
+            - '${INTERFACE}:${PORT_HTTPS}:443'
+        links:
+            - app
+        networks:
+            - mpgram
+        restart: unless-stopped
+
+    app:
+        build:
+            context: mpgram_web
+            args:
+                UID: ${UID}
+        volumes:
+            - ./logs/nginx:/var/log/nginx
+            - ./logs/php:/var/log/php
+            - /etc/localtime:/etc/localtime/:ro
+            - ../:/var/www/mpgram:rw
+
+        restart: unless-stopped
+        networks:
+            - mpgram
+
+    composer:
+      image: composer/composer
+      networks:
+        - mpgram
+      volumes_from:
+        - app
+      working_dir: /var/www/mpgram
+      command: install
+
+networks:
+    mpgram:
+        driver: bridge
+        ipam:
+            driver: default
+            config:
+                - subnet: 10.100.0.0/24
+

--- a/docker/mpgram_web/Dockerfile
+++ b/docker/mpgram_web/Dockerfile
@@ -1,0 +1,21 @@
+FROM phpdockerio/php:8.2-fpm
+
+ARG UID
+
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+    php8.2-mbstring \
+    php8.2-gd \
+    curl \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+COPY ./php.ini /etc/php/8.2/fpm/conf.d/90-php.ini
+COPY ./php.ini /etc/php/8.2/cli/conf.d/90-php.ini
+
+RUN curl -o /usr/local/etc/browscap.ini http://browscap.org/stream?q=Lite_PHP_BrowsCapINI
+
+RUN usermod -u ${UID} www-data
+
+WORKDIR "/var/www/mpgram"
+
+EXPOSE 9000

--- a/docker/mpgram_web/php.ini
+++ b/docker/mpgram_web/php.ini
@@ -1,0 +1,27 @@
+[php]
+short_open_tag = On
+display_errors = On
+error_log = "/var/log/php/error.log"
+error_reporting = E_ALL ^ E_DEPRECATED ^ E_WARNING
+log_errors = On
+display_startup_errors = On
+cgi.fix_pathinfo = 0
+date.timezone = "Europe/Moscow"
+mbstring.internal_encoding = "UTF-8"
+max_input_vars = 10000
+post_max_size = 1024M
+memory_limit = 2048M
+upload_max_filesize = 1024M
+
+[opcache]
+opcache.revalidate_freq = 0
+opcache.validate_timestamps = 1
+opcache.max_accelerated_files = 100000
+opcache.memory_consumption = 512
+opcache.interned_strings_buffer = 64
+opcache.fast_shutdown = 1
+opcache.error_log = "/var/log/php/opcache.log"
+
+[browscap]
+; http://php.net/browscap
+browscap = "/usr/local/etc/browscap.ini"

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,16 @@
+FROM nginx:1.20.2
+
+ARG UID
+ARG PROTO
+
+COPY conf/nginx.conf /etc/nginx/
+COPY conf/${PROTO}.conf /etc/nginx/conf.d/default.conf
+COPY conf/upstream.conf /etc/nginx/conf.d/
+
+COPY ssl /etc/nginx/ssl
+
+RUN usermod -u ${UID} www-data
+
+CMD ["nginx"]
+
+EXPOSE 80 443

--- a/docker/nginx/conf/http.conf
+++ b/docker/nginx/conf/http.conf
@@ -1,0 +1,41 @@
+server {
+    listen 80 deferred reuseport default;
+    listen [::]:80 deferred reuseport default;
+
+    server_name mpgram;
+
+    root  /var/www/mpgram;
+
+    access_log /var/log/nginx/mpgram-access.log;
+    error_log /var/log/nginx/mpgram-error.log;
+
+    location / {
+        index index.html index.htm index.php;
+    }
+
+    location ~ (/s/|MadelineProto.log) {
+        deny all;
+    }
+
+    location ~ \.php$ {
+        # 404
+        try_files $fastcgi_script_name =404;
+
+        include fastcgi_params;
+
+        fastcgi_pass app-upstream;
+
+        fastcgi_index index.php;
+        fastcgi_send_timeout 21600;
+        fastcgi_read_timeout 21600;
+
+        # make SERVER_NAME behave same as HTTP_HOST
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    }
+
+    error_page 404 /404.html;
+
+    location /404.html {}
+}

--- a/docker/nginx/conf/https.conf
+++ b/docker/nginx/conf/https.conf
@@ -1,0 +1,58 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    # Redirect HTTP to HTTPS
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    ssl_certificate /etc/nginx/ssl/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+    ssl_session_cache  builtin:1000  shared:SSL:10m;
+    ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+    ssl_prefer_server_ciphers on;
+
+    server_name mpgram;
+
+    root  /var/www/mpgram;
+
+    access_log /var/log/nginx/mpgram-access.log;
+    error_log /var/log/nginx/mpgram-error.log;
+
+    location / {
+        index index.html index.htm index.php;
+    }
+
+    location ~ (/s/|MadelineProto.log) {
+      deny all;
+    }
+
+    location ~ \.php$ {
+        # 404
+        try_files $fastcgi_script_name =404;
+
+        include fastcgi_params;
+
+        fastcgi_pass app-upstream;
+
+        fastcgi_index index.php;
+        fastcgi_send_timeout 21600;
+        fastcgi_read_timeout 21600;
+
+        # make SERVER_NAME behave same as HTTP_HOST
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param SERVER_NAME $host;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    }
+
+
+    error_page 404 /404.html;
+
+    location /404.html {}
+}

--- a/docker/nginx/conf/nginx.conf
+++ b/docker/nginx/conf/nginx.conf
@@ -1,0 +1,62 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 2048;
+    multi_accept on;
+    use epoll;
+}
+
+http {
+    # Main settings
+    client_body_buffer_size         4m;
+    client_body_timeout             60s;
+    client_header_buffer_size       2k;
+    client_header_timeout           60s;
+    client_max_body_size            20m;
+    keepalive_timeout               60s;
+    large_client_header_buffers     4   8k;
+    reset_timedout_connection       on;
+    send_timeout                    60s;
+    sendfile                        on;
+    server_name_in_redirect         off;
+    server_names_hash_bucket_size   512;
+    server_names_hash_max_size      512;
+    server_tokens                   off;
+    tcp_nodelay                     on;
+    tcp_nopush                      on;
+    types_hash_max_size             2048;
+    merge_slashes                   off;
+    error_log                       /var/log/nginx/default-error.log;
+    access_log                      /var/log/nginx/default-access.log;
+
+    include                         /etc/nginx/mime.types;
+    default_type                    application/octet-stream;
+
+    # Compression
+    gzip                on;
+    gzip_static         on;
+    gzip_vary           on;
+    gzip_comp_level     6;
+    gzip_min_length     512;
+    gzip_buffers        8 64k;
+    gzip_types          text/plain text/css text/javascript text/js text/xml application/json application/javascript application/x-javascript application/xml application/xml+rss application/x-font-ttf image/svg+xml font/opentype;
+    gzip_proxied        any;
+    gzip_disable        "msie6";
+    gzip_http_version   1.0;
+
+    # Log format
+    log_format postdata '$remote_addr - $remote_user [$time_local] "$request" $status $bytes_sent "$http_referer" "$http_user_agent" "$request_body"';
+
+    # File cache settings
+    open_file_cache          max=10000 inactive=30s;
+    open_file_cache_valid    60s;
+    open_file_cache_min_uses 2;
+    open_file_cache_errors   off;
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-available/*;
+}
+
+daemon off;

--- a/docker/nginx/conf/upstream.conf
+++ b/docker/nginx/conf/upstream.conf
@@ -1,0 +1,3 @@
+upstream app-upstream {
+    server app:9000;
+}


### PR DESCRIPTION
Hi Shinovon,

This PR adds a docker-compose setup which should hopefully push more folks to run their own mpgram-web instances.

This setup is mostly working for me except an issue with the login flow:

* With 2FA disabled:

    1. I can go through `phone number -> captcha -> code`  sequence
    2. But then I am stuck at `login.php` loading forever
    3. However if I then just go to `chats.php` the app works fine. 
 
* With 2FA enabled:

    1. I can go through `phone number -> captcha -> code -> Pass-code`  sequence
    2. I am then getting an `Invalid pass-code hash` error.

It would be great if you could help debug those. Also if you could review `php.ini` and all the `fastcgi` params in the nginx configs - I don't have a good idea of optimal settings.

Thanks again for mpgram-web!