### PR TITLE
php-gd fix for images in debian 12

### DIFF
--- a/docker/mpgram_web/Dockerfile
+++ b/docker/mpgram_web/Dockerfile
@@ -3,6 +3,11 @@ FROM phpdockerio/php:8.3-fpm
 ARG UID
 
 RUN apt-get update \
+    && apt-get install -y gnupg curl \
+    && curl -fsSL https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /usr/share/keyrings/php.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/php.gpg] https://packages.sury.org/php/ bullseye main" > /etc/apt/sources.list.d/php.list \
+    && apt-get update \
+    && apt-get install -y php8.3-gd \
     && apt-get -y --no-install-recommends install \
     php8.3-mbstring \
     php8.3-gd \
@@ -10,7 +15,7 @@ RUN apt-get update \
     php8.3-gmp \
     php8.3-iconv \
     php8.3-xml \
-    php8.3-json \
+  # php8.3-json \ PHP8.3-JSON is not shipped as a separate component anymore
     php8.3-fileinfo \
     curl \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*


### PR DESCRIPTION
Images are broken in debian >=12 (and ubuntu 22.x). This change in the Dockerfile adds the required php package to fix the issue. Also deprecating php8.3-json, which is not available as a separate component anymore and throws out an error in docker-compose -build